### PR TITLE
add process check when load splits

### DIFF
--- a/qigsaw-android/splitloader/src/main/java/com/iqiyi/android/qigsaw/core/splitload/SkipSplitLoadTaskImpl.java
+++ b/qigsaw-android/splitloader/src/main/java/com/iqiyi/android/qigsaw/core/splitload/SkipSplitLoadTaskImpl.java
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-present, iQIYI, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.iqiyi.android.qigsaw.core.splitload;
+
+class SkipSplitLoadTaskImpl implements Runnable {
+
+  @Override
+  public final void run() {
+    // empty
+  }
+
+}
+


### PR DESCRIPTION
A进程注册了全局的 stateupdatelistener，B进程调用startInstall 安装、加载 插件C，A进程收到广播之后也产生了加载插件C的操作

在进程触发load操作时加上对插件 workprocess 的过滤 