### PR TITLE
优化SplitCompatResourcesLoader，添加混淆规则到AAR

### DIFF
--- a/app/multidexkeep.pro
+++ b/app/multidexkeep.pro
@@ -11,7 +11,7 @@
 }
 
 # ${yourApplicationId}.QigsawConfig, QigsawVersion >= 1.2.2
--keep class com.iqiyi.qigsaw.sample.QigsawConfig {
+-keep class **.QigsawConfig {
     *;
 }
 

--- a/qigsaw-android/splitcore/build.gradle
+++ b/qigsaw-android/splitcore/build.gradle
@@ -16,6 +16,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
+            consumerProguardFiles 'proguard-rules.pro'
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/qigsaw-android/splitcore/proguard-rules.pro
+++ b/qigsaw-android/splitcore/proguard-rules.pro
@@ -20,6 +20,21 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
+#copy from multidexkeep.pro
+-keep class com.iqiyi.android.qigsaw.core.Qigsaw {
+    <init>(...);
+    void install(...);
+    void onAppGetResources(Resources);
+}
+
+# ${yourApplicationId}.QigsawConfig, QigsawVersion >= 1.2.2
+-keep class **.QigsawConfig {
+    *;
+}
+
+-keep class com.iqiyi.android.qigsaw.core.extension.ComponentInfo {
+    *;
+}
 
 
 

--- a/qigsaw-android/splitdownloader/build.gradle
+++ b/qigsaw-android/splitdownloader/build.gradle
@@ -16,6 +16,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
+            consumerProguardFiles 'proguard-rules.pro'
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/qigsaw-android/splitdownloader/proguard-rules.pro
+++ b/qigsaw-android/splitdownloader/proguard-rules.pro
@@ -20,6 +20,10 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
+#copy from multidexkeep.pro
+-keep class * implements com.iqiyi.android.qigsaw.core.splitdownload.Downloader {
+    <init>(...);
+}
 
 
 

--- a/qigsaw-android/splitloader/src/main/java/com/iqiyi/android/qigsaw/core/splitload/compat/SplitResourcesLoader.java
+++ b/qigsaw-android/splitloader/src/main/java/com/iqiyi/android/qigsaw/core/splitload/compat/SplitResourcesLoader.java
@@ -1,0 +1,15 @@
+package com.iqiyi.android.qigsaw.core.splitload.compat;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import androidx.annotation.NonNull;
+
+/**
+ * fetch with ServiceLoader
+ */
+public interface SplitResourcesLoader {
+    void loadResources(@NonNull Context context, @NonNull Resources resources) throws Throwable;
+
+    void loadResources(@NonNull Context context, @NonNull Resources preResources, @NonNull String splitApkPath) throws Throwable;
+}


### PR DESCRIPTION
- 解决：去掉fullyLoadedRes缓存（逻辑不严谨，运行速度也低）。预留ResourcesLoader接口，可方便自定义实现。
- include ProGuard rules to AAR