### PR TITLE
修复宿主 app 应用 resguard 插件后导致分包的 ABI APK 包大小增加问题 & 7z 深度压缩导致资源找不到问题

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,12 +64,6 @@ def qigsawPath = file("qigsaw/")
 qigsawSplit {
 
     /**
-     * Whether repack base apk with 7z format.
-     * default value is {@code false}
-     */
-    use7z = false
-
-    /**
      * optional，default 'null'
      * if you want to update split version, oldApk must be set.
      */

--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/QigsawAppBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/QigsawAppBasePlugin.groovy
@@ -192,13 +192,11 @@ class QigsawAppBasePlugin extends QigsawPlugin {
                         SplitBaseApkForABIsTask splitBaseApkForABIs = project.tasks.create("split${baseVariant.name.capitalize()}BaseApkForABIs", SplitBaseApkForABIsTask)
                         splitBaseApkForABIs.baseVariant = baseVariant
                         splitBaseApkForABIs.apkSigner = apkSigner
-                        splitBaseApkForABIs.use7z = QigsawSplitExtensionHelper.isUse7z(project)
                         splitBaseApkForABIs.dynamicFeaturesNames = dynamicFeaturesNames
                         splitBaseApkForABIs.baseAppCpuAbiListFile = baseAppCpuAbiListFile
                         splitBaseApkForABIs.baseApkFiles = baseApkFiles
                         splitBaseApkForABIs.packageAppDir = packageAppDir
                         splitBaseApkForABIs.baseApksDir = baseApksDir
-                        splitBaseApkForABIs.unzipBaseApkDir = unzipBaseApkDir
                         Task resguardTask = AGPCompat.getResguardTask(project, "${baseVariant.name.capitalize()}")
                         // apply plugin: 'AndResGuard' 必须在 qigsaw application 插件后应用，否则会查找不到 resguardTask
                         if (resguardTask != null) {

--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/QigsawAppBasePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/QigsawAppBasePlugin.groovy
@@ -199,8 +199,19 @@ class QigsawAppBasePlugin extends QigsawPlugin {
                         splitBaseApkForABIs.packageAppDir = packageAppDir
                         splitBaseApkForABIs.baseApksDir = baseApksDir
                         splitBaseApkForABIs.unzipBaseApkDir = unzipBaseApkDir
-                        baseAssemble.dependsOn splitBaseApkForABIs
-                        packageApp.finalizedBy splitBaseApkForABIs
+                        Task resguardTask = AGPCompat.getResguardTask(project, "${baseVariant.name.capitalize()}")
+                        // apply plugin: 'AndResGuard' 必须在 qigsaw application 插件后应用，否则会查找不到 resguardTask
+                        if (resguardTask != null) {
+                            SplitLogger.w("found resguardTask")
+                            resguardTask.dependsOn baseAssemble
+                            baseAssemble.finalizedBy resguardTask
+                            splitBaseApkForABIs.dependsOn resguardTask
+                            resguardTask.finalizedBy splitBaseApkForABIs
+                        } else {
+                            SplitLogger.w("not found resguardTask")
+                            baseAssemble.dependsOn splitBaseApkForABIs
+                            packageApp.finalizedBy splitBaseApkForABIs
+                        }
                     }
 
                     //for supporting split content-provider

--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/extension/QigsawSplitExtension.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/extension/QigsawSplitExtension.groovy
@@ -31,12 +31,6 @@ class QigsawSplitExtension {
     final static String EMPTY = ""
 
     /**
-     * Whether repack base apk with 7z format.
-     * default value is {@code false}
-     */
-    boolean use7z = false
-
-    /**
      * the old apk path
      */
     String oldApk = EMPTY

--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/extension/QigsawSplitExtensionHelper.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/extension/QigsawSplitExtensionHelper.groovy
@@ -93,14 +93,6 @@ class QigsawSplitExtensionHelper {
         return null
     }
 
-    static boolean isUse7z(Project project) {
-        try {
-            return project.extensions.qigsawSplit.use7z
-        } catch (Throwable ignored) {
-            return false
-        }
-    }
-
     static Set<String> getSplitEntryFragments(Project project) {
         try {
             List<String> value = project.extensions.qigsawSplit.splitEntryFragments

--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/internal/tool/AGPCompat.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/internal/tool/AGPCompat.groovy
@@ -249,4 +249,8 @@ class AGPCompat {
         return task
     }
 
+    static Task getResguardTask(Project project, String variantName) {
+        String resguardTaskName = "resguard${variantName}"
+        return project.tasks.findByName(resguardTaskName)
+    }
 }


### PR DESCRIPTION
问题1: 宿主 app 使用 rearguard 插件，打出的 abi 包大小增大
需要等待 resguard  处理完成后再进行分包。

以我们的应用为例，修复前 v7a 的包大小为 127M，修复后包大小为 119M

问题2: 7z 深度压缩(-mx9) 导致 resources.arsc 出问题，运行时资源找不到

不使用 7z 压缩(即不侵入修改宿主 app 的打包压缩流程，只复制全包后进行 zip 操作文件

