### PR TITLE
fix: set xml file encoding

### DIFF
--- a/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/task/QigsawProcessManifestTask.groovy
+++ b/buildSrc/src/main/groovy/com/iqiyi/qigsaw/buildtool/gradle/task/QigsawProcessManifestTask.groovy
@@ -94,7 +94,7 @@ class QigsawProcessManifestTask extends DefaultTask {
         OutputFormat format = OutputFormat.createPrettyPrint()
         format.setEncoding("UTF-8")
         XMLWriter writer = new XMLWriter(
-                new OutputStreamWriter(new FileOutputStream(xmlFile)), format)
+                new OutputStreamWriter(new FileOutputStream(xmlFile), "UTF-8"), format)
         writer.write(document)
         writer.close()
     }


### PR DESCRIPTION
windows环境AndroidManifest包含中文注释，编译失败，生成的AndroidManifest中文乱码，这里指定文件编码格式。
```
> Task :app:processDebugResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugResources'.
> Android resource linking failed
  xxxx\Qigsaw\app\build\intermediates\merged_manifests\debug\AndroidManifest.xml:14: AAPT: error: not well-formed (invalid token).
```